### PR TITLE
fix: Update Azure endpoint for govcloud region in compute.tf

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -77,7 +77,7 @@ locals {
     tfe_object_storage_azure_account_key  = !var.tfe_object_storage_azure_use_msi ? local.tfe_object_storage_azure_account_key : ""
     tfe_object_storage_azure_account_name = var.is_secondary_region ? data.azurerm_storage_account.tfe[0].name : azurerm_storage_account.tfe[0].name
     tfe_object_storage_azure_container    = var.is_secondary_region ? data.azurerm_storage_container.tfe[0].name : azurerm_storage_container.tfe[0].name
-    tfe_object_storage_azure_endpoint     = var.is_govcloud_region ? split(".blob.", azurerm_storage_account.tfe[0].primary_blob_host)[1] : ""
+    tfe_object_storage_azure_endpoint     = var.is_govcloud_region ? "blob.core.usgovcloudapi.net" : ""
     tfe_object_storage_azure_use_msi      = var.tfe_object_storage_azure_use_msi
     tfe_object_storage_azure_client_id    = var.tfe_object_storage_azure_use_msi ? azurerm_user_assigned_identity.tfe.client_id : ""
 


### PR DESCRIPTION
## Description
This pull request includes a change to the `compute.tf` file to improve the handling of Azure endpoint configuration for government cloud regions. The most important change is:

* Modified the `tfe_object_storage_azure_endpoint` to use a static endpoint `"blob.core.usgovcloudapi.net"` instead of splitting the primary blob host for government cloud regions.

## Related issue
n/a

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
terraform validate and terraform plan/apply

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes
n/a
