### PR TITLE
feat: add explorer database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ One of the following logging destinations for the TFE container logs:
 
 1. Follow the steps to [create the TFE initial admin user](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/initial-admin-user).
 
+>📝 Note: Explorer can be enabled with a dedicated PostgreSQL connection, or by reusing the primary TFE PostgreSQL database for non-production use.
+
 ## Docs
 
 Below are links to various docs related to the customization and management of your TFE deployment:
@@ -315,6 +317,12 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_capacity_memory"></a> [tfe\_capacity\_memory](#input\_tfe\_capacity\_memory) | Amount of memory in MB for TFE. | `number` | `2048` | no |
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | PostgreSQL database name for TFE. | `string` | `"tfe"` | no |
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | PostgreSQL server parameters for the connection URI. Used to configure the PostgreSQL connection. | `string` | `"sslmode=require"` | no |
+| <a name="input_tfe_explorer_database_host"></a> [tfe\_explorer\_database\_host](#input\_tfe\_explorer\_database\_host) | PostgreSQL server for Explorer in `HOST[:PORT]` format. Leave as `null` to reuse the primary TFE database for non-production use. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_name"></a> [tfe\_explorer\_database\_name](#input\_tfe\_explorer\_database\_name) | Name of the PostgreSQL database used by Explorer. Leave as `null` to reuse the primary TFE database for non-production use. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_parameters"></a> [tfe\_explorer\_database\_parameters](#input\_tfe\_explorer\_database\_parameters) | PostgreSQL server parameters for the Explorer connection URI. Leave as `null` to reuse `tfe_database_parameters`. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_password_keyvault_secret_id"></a> [tfe\_explorer\_database\_password\_keyvault\_secret\_id](#input\_tfe\_explorer\_database\_password\_keyvault\_secret\_id) | ID of the Key Vault secret containing the Explorer database password. Leave as `null` to reuse the primary TFE database password for non-production use. | `string` | `null` | no |
+| <a name="input_tfe_explorer_database_user"></a> [tfe\_explorer\_database\_user](#input\_tfe\_explorer\_database\_user) | PostgreSQL username used by Explorer. Leave as `null` to reuse the primary TFE database for non-production use. | `string` | `null` | no |
+| <a name="input_tfe_explorer_enabled"></a> [tfe\_explorer\_enabled](#input\_tfe\_explorer\_enabled) | Boolean to enable Terraform Enterprise Explorer. | `bool` | `false` | no |
 | <a name="input_tfe_hairpin_addressing"></a> [tfe\_hairpin\_addressing](#input\_tfe\_hairpin\_addressing) | Boolean to enable hairpin addressing for layer 4 load balancer with loopback prevention. Must be `true` when `lb_is_internal` is `true`. | `bool` | `true` | no |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port for TFE application containers to listen on. | `number` | `8080` | no |
 | <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port for TFE application containers to listen on. | `number` | `8443` | no |
@@ -356,6 +364,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 |------|-------------|
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | FQDN and port of PostgreSQL Flexible Server. |
 | <a name="output_tfe_database_name"></a> [tfe\_database\_name](#output\_tfe\_database\_name) | Name of PostgreSQL Flexible Server database. |
+| <a name="output_tfe_explorer_database_warning"></a> [tfe\_explorer\_database\_warning](#output\_tfe\_explorer\_database\_warning) | Warning emitted when Explorer reuses the primary TFE database. |
 | <a name="output_tfe_object_storage_azure_account_name"></a> [tfe\_object\_storage\_azure\_account\_name](#output\_tfe\_object\_storage\_azure\_account\_name) | Name of primary TFE Azure Storage Account. |
 | <a name="output_tfe_object_storage_azure_container_name"></a> [tfe\_object\_storage\_azure\_container\_name](#output\_tfe\_object\_storage\_azure\_container\_name) | Name of TFE Azure Storage Container. |
 | <a name="output_url"></a> [url](#output\_url) | URL of TFE application based on `tfe_fqdn` input. |

--- a/compute.tf
+++ b/compute.tf
@@ -30,6 +30,7 @@ locals {
 # Custom data (cloud-init) script arguments
 #------------------------------------------------------------------------------
 locals {
+  tfe_explorer_uses_primary_database   = var.tfe_explorer_enabled && var.tfe_explorer_database_host == null
   tfe_startup_script_tpl               = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_custom_data.sh.tpl"
   redis_port                           = var.tfe_redis_use_tls ? 6380 : 6379
   tfe_object_storage_azure_account_key = var.is_secondary_region ? data.azurerm_storage_account.tfe[0].primary_access_key : azurerm_storage_account.tfe[0].primary_access_key
@@ -71,6 +72,19 @@ locals {
     tfe_database_user       = azurerm_postgresql_flexible_server.tfe.administrator_login
     tfe_database_password   = azurerm_postgresql_flexible_server.tfe.administrator_password
     tfe_database_parameters = var.tfe_database_parameters
+    tfe_explorer_enabled    = var.tfe_explorer_enabled
+    tfe_explorer_database_host = var.tfe_explorer_enabled ? (
+      local.tfe_explorer_uses_primary_database ? "${azurerm_postgresql_flexible_server.tfe.fqdn}:5432" : var.tfe_explorer_database_host
+    ) : ""
+    tfe_explorer_database_name = var.tfe_explorer_enabled ? (
+      local.tfe_explorer_uses_primary_database ? var.tfe_database_name : var.tfe_explorer_database_name
+    ) : ""
+    tfe_explorer_database_user = var.tfe_explorer_enabled ? (
+      local.tfe_explorer_uses_primary_database ? azurerm_postgresql_flexible_server.tfe.administrator_login : var.tfe_explorer_database_user
+    ) : ""
+    tfe_explorer_database_password                    = var.tfe_explorer_enabled && local.tfe_explorer_uses_primary_database ? azurerm_postgresql_flexible_server.tfe.administrator_password : ""
+    tfe_explorer_database_password_keyvault_secret_id = var.tfe_explorer_enabled && !local.tfe_explorer_uses_primary_database ? coalesce(var.tfe_explorer_database_password_keyvault_secret_id, "") : ""
+    tfe_explorer_database_parameters                  = var.tfe_explorer_enabled ? coalesce(var.tfe_explorer_database_parameters, var.tfe_database_parameters) : ""
 
 
     # Object storage settings

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -98,6 +98,32 @@ tfe_metrics_https_port = 9091
 
 >📝 Note: Ensure your have NSG/firwall rules in place to allow `TCP/9090` or `TCP/9091` ingress to your TFE VM subnet.
 
+## Explorer
+
+Explorer is disabled by default. When enabled, you can either point it at a dedicated PostgreSQL database or leave all Explorer database inputs as `null` to reuse the primary TFE PostgreSQL database for non-production use.
+
+```hcl
+tfe_explorer_enabled                         = true
+tfe_explorer_database_host                   = "my-explorer-db.postgres.database.azure.com:5432"
+tfe_explorer_database_name                   = "tfeexplorer"
+tfe_explorer_database_user                   = "exploreradmin"
+tfe_explorer_database_password_keyvault_secret_id = "https://my-kv.vault.azure.net/secrets/explorer-password/..."
+tfe_explorer_database_parameters             = "sslmode=require"
+```
+
+For non-production environments:
+
+```hcl
+tfe_explorer_enabled                         = true
+tfe_explorer_database_host                   = null
+tfe_explorer_database_name                   = null
+tfe_explorer_database_user                   = null
+tfe_explorer_database_password_keyvault_secret_id = null
+tfe_explorer_database_parameters             = null
+```
+
+When you use the fallback mode, the module emits `tfe_explorer_database_warning` so the shared-database configuration remains visible in Terraform outputs.
+
 ## Custom VM image
 
 If a custom VM image is preferred over using a standard marketplace image, the following variables may be set:

--- a/docs/tfe-config-settings.md
+++ b/docs/tfe-config-settings.md
@@ -13,3 +13,10 @@ The [Terraform Enterprise Flexible Deployment Options configuration reference](h
 Within the [compute.tf](../compute.tf) file, you will see a `locals` block with a map inside of it called `custom_data_args`. Almost all of the TFE configuration settings are passed from here into the [tfe_custom_data.sh](../templates/tfe_custom_data.sh.tpl) script.
 
 Within the [tfe_custom_data.sh](../templates/tfe_custom_data.sh.tpl) script there is a function named `generate_tfe_docker_compose` that is responsible for receiving all of those inputs and dynamically generating the `docker-compose.yaml` file. After a successful install process, this can be found on your TFE VM(s) within `/etc/tfe/docker-compose.yaml`.
+
+## Explorer settings
+
+When `tfe_explorer_enabled` is `true`, the module renders `TFE_EXPLORER_DATABASE_*` settings into the generated Docker Compose and Podman manifests. The effective Explorer database connection is computed in `compute.tf`:
+
+- dedicated Explorer connection when all Explorer database inputs are supplied
+- fallback to the primary TFE PostgreSQL connection when Explorer is enabled and dedicated Explorer DB inputs are omitted

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -56,3 +56,13 @@ Supported values:
 Supported values:
 - `log_analytics` - sets a Log Analytics workspace; `log_analytics_workspace_name` is also required
 - `custom` - sets a custom logging destination; specify your own custom FluentBit config via `custom_fluent_bit_config`
+
+### Explorer
+
+**Input variable:** `tfe_explorer_enabled`
+
+Supported values:
+- `false` - default
+- `true` - enables Terraform Enterprise Explorer
+
+When Explorer is enabled, either set the Explorer database inputs to a dedicated PostgreSQL connection and Key Vault password secret, or leave them all `null` to reuse the primary TFE database in non-production environments.

--- a/examples/main/main.tf
+++ b/examples/main/main.tf
@@ -45,6 +45,7 @@ module "tfe" {
   tfe_metrics_http_port    = var.tfe_metrics_http_port
   tfe_metrics_https_port   = var.tfe_metrics_https_port
   tfe_operational_mode     = var.tfe_operational_mode
+  tfe_explorer_enabled     = var.tfe_explorer_enabled
 
   # --- Networking --- #
   vnet_id         = var.vnet_id
@@ -70,14 +71,19 @@ module "tfe" {
   vm_admin_username   = var.vm_admin_username
 
   # --- Database --- #
-  tfe_database_password_keyvault_secret_name = var.tfe_database_password_keyvault_secret_name
-  tfe_database_name                          = var.tfe_database_name
-  tfe_database_parameters                    = var.tfe_database_parameters
-  postgres_enable_high_availability          = var.postgres_enable_high_availability
-  postgres_geo_redundant_backup_enabled      = var.postgres_geo_redundant_backup_enabled
-  postgres_administrator_login               = var.postgres_administrator_login
-  postgres_version                           = var.postgres_version
-  postgres_sku                               = var.postgres_sku
+  tfe_database_password_keyvault_secret_name        = var.tfe_database_password_keyvault_secret_name
+  tfe_database_name                                 = var.tfe_database_name
+  tfe_database_parameters                           = var.tfe_database_parameters
+  tfe_explorer_database_host                        = var.tfe_explorer_database_host
+  tfe_explorer_database_name                        = var.tfe_explorer_database_name
+  tfe_explorer_database_user                        = var.tfe_explorer_database_user
+  tfe_explorer_database_password_keyvault_secret_id = var.tfe_explorer_database_password_keyvault_secret_id
+  tfe_explorer_database_parameters                  = var.tfe_explorer_database_parameters
+  postgres_enable_high_availability                 = var.postgres_enable_high_availability
+  postgres_geo_redundant_backup_enabled             = var.postgres_geo_redundant_backup_enabled
+  postgres_administrator_login                      = var.postgres_administrator_login
+  postgres_version                                  = var.postgres_version
+  postgres_sku                                      = var.postgres_sku
 
   # --- Object storage --- #
   storage_account_ip_allow = var.storage_account_ip_allow

--- a/examples/main/terraform.tfvars.example
+++ b/examples/main/terraform.tfvars.example
@@ -29,6 +29,7 @@ tfe_capacity_memory      = <2048>            # Maximum amount of memory (MiB) a 
 tfe_metrics_enable       = <false>
 tfe_metrics_http_port    = <9090>
 tfe_metrics_https_port   = <9091>
+tfe_explorer_enabled     = <false>
 
 # --- Networking --- #
 vnet_id         = "<tfe-vnet-id>"
@@ -60,6 +61,11 @@ postgres_geo_redundant_backup_enabled      = <true>
 postgres_administrator_login               = "<tfeadmin>"
 tfe_database_name                          = "<tfe>"
 tfe_database_parameters                    = "<sslmode=require>"
+tfe_explorer_database_host                 = null # set Explorer host, name, user, and password secret together, or leave all null to reuse the primary TFE database for non-production use
+tfe_explorer_database_name                 = null
+tfe_explorer_database_user                 = null
+tfe_explorer_database_password_keyvault_secret_id = null
+tfe_explorer_database_parameters           = null
 postgres_version                           = "16"
 postgres_sku                               = "<GP_Standard_D4ds_v4>"
 

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -247,6 +247,50 @@ variable "tfe_metrics_https_port" {
   default     = 9091
 }
 
+variable "tfe_explorer_enabled" {
+  type        = bool
+  description = "Boolean to enable Terraform Enterprise Explorer."
+  default     = false
+}
+
+variable "tfe_explorer_database_host" {
+  type        = string
+  description = "PostgreSQL server for Explorer in `HOST[:PORT]` format. Leave as `null` to reuse the primary TFE database for non-production use."
+  default     = null
+
+  validation {
+    condition = !var.tfe_explorer_enabled || (
+      (var.tfe_explorer_database_host == null && var.tfe_explorer_database_name == null && var.tfe_explorer_database_user == null && var.tfe_explorer_database_password_keyvault_secret_id == null) ||
+      (var.tfe_explorer_database_host != null && var.tfe_explorer_database_name != null && var.tfe_explorer_database_user != null && var.tfe_explorer_database_password_keyvault_secret_id != null)
+    )
+    error_message = "Explorer database host, name, user, and password secret must either all be set or all be null when Explorer is enabled."
+  }
+}
+
+variable "tfe_explorer_database_name" {
+  type        = string
+  description = "Name of the PostgreSQL database used by Explorer. Leave as `null` to reuse the primary TFE database for non-production use."
+  default     = null
+}
+
+variable "tfe_explorer_database_user" {
+  type        = string
+  description = "PostgreSQL username used by Explorer. Leave as `null` to reuse the primary TFE database for non-production use."
+  default     = null
+}
+
+variable "tfe_explorer_database_password_keyvault_secret_id" {
+  type        = string
+  description = "ID of the Key Vault secret containing the Explorer database password. Leave as `null` to reuse the primary TFE database password for non-production use."
+  default     = null
+}
+
+variable "tfe_explorer_database_parameters" {
+  type        = string
+  description = "PostgreSQL server parameters for the Explorer connection URI. Leave as `null` to reuse `tfe_database_parameters`."
+  default     = null
+}
+
 variable "tfe_tls_enforce" {
   type        = bool
   description = "Boolean to enforce TLS, Strict-Transport-Security headers, and secure cookies within TFE."

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,11 @@ output "url" {
   description = "URL of TFE application based on `tfe_fqdn` input."
 }
 
+output "tfe_explorer_database_warning" {
+  value       = var.tfe_explorer_enabled && local.tfe_explorer_uses_primary_database ? "Explorer is enabled and reuses the primary TFE PostgreSQL database. This fallback is intended for non-production use." : null
+  description = "Warning emitted when Explorer reuses the primary TFE database."
+}
+
 #------------------------------------------------------------------------------
 # Database
 #------------------------------------------------------------------------------
@@ -34,4 +39,3 @@ output "tfe_object_storage_azure_container_name" {
   value       = try(azurerm_storage_container.tfe[0].name, null)
   description = "Name of TFE Azure Storage Container."
 }
-

--- a/specs/explorer-support/plan.md
+++ b/specs/explorer-support/plan.md
@@ -1,0 +1,13 @@
+# Plan: Terraform Enterprise Explorer support
+
+## Implementation approach
+
+1. Add Explorer variables for enablement, host, name, user, parameters, and Key Vault secret reference for the password.
+2. Compute effective Explorer database settings in `compute.tf`, defaulting to the primary TFE database when dedicated settings are omitted.
+3. Extend the startup template to export Explorer settings for both Docker and Podman manifests.
+4. Add outputs, example wiring, and documentation for dedicated and fallback modes.
+
+## Azure-specific notes
+
+- Reuse the existing Key Vault secret and PostgreSQL patterns instead of AWS IAM or Secrets Manager features.
+- Keep the initial Azure port to password-based Explorer database access unless a product-supported Azure passwordless mode is confirmed.

--- a/specs/explorer-support/spec.md
+++ b/specs/explorer-support/spec.md
@@ -1,0 +1,21 @@
+# Spec: Terraform Enterprise Explorer support
+
+## Summary
+
+Port Terraform Enterprise Explorer configuration support into the Azure TFE VM module using Azure-native database and secret patterns.
+
+## Requirements
+
+1. The module must support enabling Explorer independently of the core TFE deployment.
+2. The module must support Explorer using either dedicated database settings or a fallback to the primary TFE database for non-production use.
+3. Explorer database credentials must follow the module's Azure Key Vault pattern.
+4. The module must emit a warning output when Explorer is enabled but reuses the primary TFE database.
+5. Docs and examples must explain the Azure-specific Explorer database configuration.
+
+## Acceptance criteria
+
+- New Explorer variables are exposed in `variables.tf` and `examples/main/variables.tf`.
+- `compute.tf` computes effective Explorer DB settings and passes them into the startup template.
+- Docker and Podman runtime config include `TFE_EXPLORER_DATABASE_*` env vars when Explorer is enabled.
+- `outputs.tf` includes a warning output for shared-database fallback.
+- The module validates from the root and `examples/main`.

--- a/specs/explorer-support/tasks.md
+++ b/specs/explorer-support/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Terraform Enterprise Explorer support
+
+1. Add Explorer inputs and effective-value locals in `variables.tf` and `compute.tf`.
+2. Update `templates/tfe_custom_data.sh.tpl` and `outputs.tf`.
+3. Update `examples/main/*`, `README.md`, and docs.
+4. Run `task test` and `task terraform-docs`.
+

--- a/templates/tfe_custom_data.sh.tpl
+++ b/templates/tfe_custom_data.sh.tpl
@@ -181,6 +181,13 @@ services:
       TFE_DATABASE_USER: ${tfe_database_user}
       TFE_DATABASE_PASSWORD: ${tfe_database_password}
       TFE_DATABASE_PARAMETERS: ${tfe_database_parameters}
+%{ if tfe_explorer_enabled ~}
+      TFE_EXPLORER_DATABASE_HOST: ${tfe_explorer_database_host}
+      TFE_EXPLORER_DATABASE_NAME: ${tfe_explorer_database_name}
+      TFE_EXPLORER_DATABASE_USER: ${tfe_explorer_database_user}
+      TFE_EXPLORER_DATABASE_PARAMETERS: ${tfe_explorer_database_parameters}
+      TFE_EXPLORER_DATABASE_PASSWORD: $TFE_EXPLORER_DATABASE_PASSWORD
+%{ endif ~}
 
       # Object storage settings
       TFE_OBJECT_STORAGE_TYPE: ${tfe_object_storage_type}
@@ -341,6 +348,18 @@ spec:
       value: ${tfe_database_password}
     - name: "TFE_DATABASE_USER"
       value: ${tfe_database_user}
+%{ if tfe_explorer_enabled ~}
+    - name: "TFE_EXPLORER_DATABASE_HOST"
+      value: ${tfe_explorer_database_host}
+    - name: "TFE_EXPLORER_DATABASE_NAME"
+      value: ${tfe_explorer_database_name}
+    - name: "TFE_EXPLORER_DATABASE_USER"
+      value: ${tfe_explorer_database_user}
+    - name: "TFE_EXPLORER_DATABASE_PARAMETERS"
+      value: ${tfe_explorer_database_parameters}
+    - name: "TFE_EXPLORER_DATABASE_PASSWORD"
+      value: $TFE_EXPLORER_DATABASE_PASSWORD
+%{ endif ~}
 
     # Object storage settings
     - name: "TFE_OBJECT_STORAGE_TYPE"
@@ -587,6 +606,16 @@ function main {
 
   log "INFO" "Retrieving 'TFE_ENCRYPTION_PASSWORD' from Key Vault secret ${tfe_encryption_password_keyvault_secret_id}..."
   TFE_ENCRYPTION_PASSWORD=$(retrieve_secret_from_key_vault "${tfe_encryption_password_keyvault_secret_id}")
+
+  if [[ "${tfe_explorer_enabled}" == "true" ]]; then
+    if [[ -n "${tfe_explorer_database_password_keyvault_secret_id}" ]]; then
+      log "INFO" "Retrieving Explorer database password from Key Vault secret ${tfe_explorer_database_password_keyvault_secret_id}..."
+      TFE_EXPLORER_DATABASE_PASSWORD=$(retrieve_secret_from_key_vault "${tfe_explorer_database_password_keyvault_secret_id}")
+    else
+      log "INFO" "Explorer is reusing the primary TFE database password."
+      TFE_EXPLORER_DATABASE_PASSWORD="${tfe_explorer_database_password}"
+    fi
+  fi
 
   if [[ "${tfe_log_forwarding_enabled}" == "true" ]]; then
     log "INFO" "Generating '$TFE_LOG_FORWARDING_CONFIG_PATH' file for TFE log forwarding via Fluent Bit."

--- a/variables.tf
+++ b/variables.tf
@@ -247,6 +247,50 @@ variable "tfe_metrics_https_port" {
   default     = 9091
 }
 
+variable "tfe_explorer_enabled" {
+  type        = bool
+  description = "Boolean to enable Terraform Enterprise Explorer."
+  default     = false
+}
+
+variable "tfe_explorer_database_host" {
+  type        = string
+  description = "PostgreSQL server for Explorer in `HOST[:PORT]` format. Leave as `null` to reuse the primary TFE database for non-production use."
+  default     = null
+
+  validation {
+    condition = !var.tfe_explorer_enabled || (
+      (var.tfe_explorer_database_host == null && var.tfe_explorer_database_name == null && var.tfe_explorer_database_user == null && var.tfe_explorer_database_password_keyvault_secret_id == null) ||
+      (var.tfe_explorer_database_host != null && var.tfe_explorer_database_name != null && var.tfe_explorer_database_user != null && var.tfe_explorer_database_password_keyvault_secret_id != null)
+    )
+    error_message = "Explorer database host, name, user, and password secret must either all be set or all be null when Explorer is enabled."
+  }
+}
+
+variable "tfe_explorer_database_name" {
+  type        = string
+  description = "Name of the PostgreSQL database used by Explorer. Leave as `null` to reuse the primary TFE database for non-production use."
+  default     = null
+}
+
+variable "tfe_explorer_database_user" {
+  type        = string
+  description = "PostgreSQL username used by Explorer. Leave as `null` to reuse the primary TFE database for non-production use."
+  default     = null
+}
+
+variable "tfe_explorer_database_password_keyvault_secret_id" {
+  type        = string
+  description = "ID of the Key Vault secret containing the Explorer database password. Leave as `null` to reuse the primary TFE database password for non-production use."
+  default     = null
+}
+
+variable "tfe_explorer_database_parameters" {
+  type        = string
+  description = "PostgreSQL server parameters for the Explorer connection URI. Leave as `null` to reuse `tfe_database_parameters`."
+  default     = null
+}
+
 variable "tfe_tls_enforce" {
   type        = bool
   description = "Boolean to enforce TLS, Strict-Transport-Security headers, and secure cookies within TFE."


### PR DESCRIPTION
This pull request adds support for configuring Terraform Enterprise Explorer in the Azure TFE VM module. It introduces new variables and logic to enable Explorer with either a dedicated PostgreSQL database or by reusing the primary TFE database for non-production environments. The changes include input validation, effective configuration computation, template updates, outputs, and comprehensive documentation and examples.

**Explorer support and configuration:**

* Added new input variables in `variables.tf` and `examples/main/variables.tf` to enable Explorer and configure its database connection, supporting both dedicated and fallback-to-primary modes. Input validation ensures all Explorer DB settings are set together or left as null for fallback. [[1]](diffhunk://#diff-3b4ab90e2764f9caa35e0227205e512a321e8ae25a0e52422b19bc38b35e86e1R250-R293) F0d6aa29L45R45, F0d6aa29L73R74, [[2]](diffhunk://#diff-11ccad520825589f8ab771a6250a24761d873b62a70dba84d9c53c9f84ea437bR32) [[3]](diffhunk://#diff-11ccad520825589f8ab771a6250a24761d873b62a70dba84d9c53c9f84ea437bR64-R68) [[4]](diffhunk://#diff-c186f2dcff21f6375467634a865790b52aafd679da3e2a397b261e40921862faR48) [[5]](diffhunk://#diff-c186f2dcff21f6375467634a865790b52aafd679da3e2a397b261e40921862faR77-R81)
* Computed effective Explorer DB settings in `compute.tf` using new locals, passing them into the startup script template for use in Docker/Podman manifests. [[1]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR33) [[2]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR75-R87)
* Updated `tfe_custom_data.sh.tpl` to export `TFE_EXPLORER_DATABASE_*` environment variables when Explorer is enabled. [[1]](diffhunk://#diff-19962760cb9c52c1f75afdc0e7add9dcb7fabb5a65d13f3fdb80a686736dc527R184-R190) [[2]](diffhunk://#diff-19962760cb9c52c1f75afdc0e7add9dcb7fabb5a65d13f3fdb80a686736dc527R351-R362)

**Outputs and warnings:**

* Added a new output `tfe_explorer_database_warning` to notify users when Explorer is enabled but reuses the primary TFE database, highlighting that this fallback is intended for non-production use. [[1]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R12-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R367)

**Documentation and examples:**

* Updated `README.md`, `deployment-customizations.md`, `tfe-config-settings.md`, and example files to document Explorer configuration, usage patterns, and Azure-specific notes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R154-R155) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R320-R325) [[3]](diffhunk://#diff-dea719bc4ba0eea545a1ecd126d81a534e54b569f2612b3ad617f810014de695R101-R126) [[4]](diffhunk://#diff-518f8c1dc1902fb42626e2f8b9bfd2618d562f09022428893490ef508f4efcb6R16-R22) [[5]](diffhunk://#diff-90d1e1caa36996671fe43f25f58256e1c6070206874b87154dde60bec46c8215R59-R68)
* Added a plan, spec, and task file in `specs/explorer-support/` describing the implementation, requirements, and acceptance criteria for Explorer support. [[1]](diffhunk://#diff-8d42eb23abb2af8af17d968434357db314853a44a0f673811c23b4b517559aefR1-R13) [[2]](diffhunk://#diff-4d809429ae1f6464fc60d42b5e17e5c3111c077ca9e96314e839899782125f3aR1-R21) [[3]](diffhunk://#diff-511cb94f9c9834ca458ca69f747893786ab89aca79a4cb066cbfc6fbdc6c5b85R1-R7)## Summary
- port the upstream Explorer support from AWS PR #47 into the Azure VM module
- support either a dedicated Explorer database or reuse of the primary TFE PostgreSQL database with Azure Key Vault bootstrap wiring
- add outputs, example usage, and spec/plan/tasks docs covering the Azure adaptation

## Upstream references
- hashicorp/terraform-aws-terraform-enterprise-hvd#47