### PR TITLE
feat: add secondary hostname support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Terraform module aligned with HashiCorp Validated Designs (HVD) to deploy Terraf
 - Redis cache subnet ID
 - Ability to create private endpoints on the database and redis cache subnets
 - Chosen fully qualified domain name (FQDN) for your TFE instance (_e.g._ `tfe.azure.example.com`)
+- Optional secondary fully qualified domain name (FQDN) for integration traffic (_e.g._ `tfe-integrations.azure.example.com`)
 
 #### Network security group (NSG)/firewall rules
 
 - Allow `TCP/443` ingress to load balancer subnet (if TFE load balancer is to be _internal_) or VM subnet (if TFE load balancer is to be _external_) from CIDR ranges of TFE users/clients, your VCS, and other systems (such as CI/CD) that will need to access TFE
+- If `create_tfe_secondary_public_endpoint = true`, allow `TCP/443` ingress to the same TFE VM path for clients that need to reach the secondary hostname
 - (Optional) Allow `TCP/9091` (HTTPS) and/or `TCP/9090` (HTTP) ingress to VM subnet from monitoring/observability tool CIDR range (for scraping TFE metrics endpoints)
 - Allow `TCP/5432` ingress to database subnet from VM subnet (for PostgreSQL traffic)
 - Allow `TCP/6380` ingress to Redis cache subnetfrom VM subnet (for Redis TLS traffic)
@@ -55,6 +57,7 @@ Azure Key Vault containing the following TFE _bootstrap_ secrets:
 - **TFE TLS certificate** - base64-encoded string of certificate file in PEM format
 - **TFE TLS private key** - base64-encoded string of private key file in PEM format
 - **TFE custom CA bundle** - base64-encoded string of custom CA bundle file in PEM format
+- **Optional secondary TFE TLS certificate, private key, and CA bundle** - required when `tfe_hostname_secondary` is set
 
  >📝 Note: See the [TFE TLS Certificate Rotation](./docs/tfe-cert-rotation.md) doc for instructions on how to base64-encode the certificates with proper formatting before storing them as Key Vault secrets.
 
@@ -189,6 +192,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | Name | Type |
 |------|------|
 | [azurerm_dns_a_record.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
+| [azurerm_dns_a_record.tfe_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_key_vault_access_policy.postgres_cmk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.storage_account_cmk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.tfe_kv_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -196,6 +200,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [azurerm_lb_backend_address_pool.tfe_servers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_backend_address_pool) | resource |
 | [azurerm_lb_probe.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_probe) | resource |
 | [azurerm_lb_rule.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_rule) | resource |
+| [azurerm_lb_rule.tfe_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_rule) | resource |
 | [azurerm_linux_virtual_machine_scale_set.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set) | resource |
 | [azurerm_postgresql_flexible_server.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
 | [azurerm_postgresql_flexible_server_configuration.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
@@ -212,6 +217,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | [azurerm_private_endpoint.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_public_ip.tfe_lb](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_public_ip.tfe_lb_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_redis_cache.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache) | resource |
 | [azurerm_resource_group.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.tfe_kv_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -264,6 +270,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Boolean to create a new resource group for this TFE deployment. | `bool` | `true` | no |
 | <a name="input_create_tfe_private_dns_record"></a> [create\_tfe\_private\_dns\_record](#input\_create\_tfe\_private\_dns\_record) | Boolean to create a DNS record for TFE in a private Azure DNS zone. A `private_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
 | <a name="input_create_tfe_public_dns_record"></a> [create\_tfe\_public\_dns\_record](#input\_create\_tfe\_public\_dns\_record) | Boolean to create a DNS record for TFE in a public Azure DNS zone. A `public_dns_zone_name` must also be provided when `true`. | `bool` | `false` | no |
+| <a name="input_create_tfe_secondary_public_dns_record"></a> [create\_tfe\_secondary\_public\_dns\_record](#input\_create\_tfe\_secondary\_public\_dns\_record) | Boolean to create a public Azure DNS record for `tfe_hostname_secondary`. | `bool` | `false` | no |
+| <a name="input_create_tfe_secondary_public_endpoint"></a> [create\_tfe\_secondary\_public\_endpoint](#input\_create\_tfe\_secondary\_public\_endpoint) | Boolean to create a managed public Azure load balancer frontend and public IP for `tfe_hostname_secondary`. | `bool` | `false` | no |
 | <a name="input_custom_fluent_bit_config"></a> [custom\_fluent\_bit\_config](#input\_custom\_fluent\_bit\_config) | Custom Fluent Bit configuration for log forwarding. Only valid if `log_fwd_destination_type` is `custom`. | `string` | `null` | no |
 | <a name="input_custom_tfe_startup_script_template"></a> [custom\_tfe\_startup\_script\_template](#input\_custom\_tfe\_startup\_script\_template) | Name of custom TFE startup script template file. File must exist within a directory named `./templates` within your current working directory. | `string` | `null` | no |
 | <a name="input_docker_version"></a> [docker\_version](#input\_docker\_version) | Version of Docker to install on TFE VMSS. | `string` | `"28.0.1"` | no |
@@ -316,6 +324,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_database_name"></a> [tfe\_database\_name](#input\_tfe\_database\_name) | PostgreSQL database name for TFE. | `string` | `"tfe"` | no |
 | <a name="input_tfe_database_parameters"></a> [tfe\_database\_parameters](#input\_tfe\_database\_parameters) | PostgreSQL server parameters for the connection URI. Used to configure the PostgreSQL connection. | `string` | `"sslmode=require"` | no |
 | <a name="input_tfe_hairpin_addressing"></a> [tfe\_hairpin\_addressing](#input\_tfe\_hairpin\_addressing) | Boolean to enable hairpin addressing for layer 4 load balancer with loopback prevention. Must be `true` when `lb_is_internal` is `true`. | `bool` | `true` | no |
+| <a name="input_tfe_hostname_secondary"></a> [tfe\_hostname\_secondary](#input\_tfe\_hostname\_secondary) | Secondary externally resolvable fully qualified domain name for TFE integration traffic such as OIDC, VCS, or run tasks. | `string` | `null` | no |
 | <a name="input_tfe_http_port"></a> [tfe\_http\_port](#input\_tfe\_http\_port) | HTTP port for TFE application containers to listen on. | `number` | `8080` | no |
 | <a name="input_tfe_https_port"></a> [tfe\_https\_port](#input\_tfe\_https\_port) | HTTPS port for TFE application containers to listen on. | `number` | `8443` | no |
 | <a name="input_tfe_image_name"></a> [tfe\_image\_name](#input\_tfe\_image\_name) | Name of the TFE container image. Only change this if you are hosting the TFE container image in your own custom repository. | `string` | `"hashicorp/terraform-enterprise"` | no |
@@ -329,6 +338,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_metrics_http_port"></a> [tfe\_metrics\_http\_port](#input\_tfe\_metrics\_http\_port) | HTTP port for TFE metrics endpoint. | `number` | `9090` | no |
 | <a name="input_tfe_metrics_https_port"></a> [tfe\_metrics\_https\_port](#input\_tfe\_metrics\_https\_port) | HTTPS port for TFE metrics endpoint. | `number` | `9091` | no |
 | <a name="input_tfe_object_storage_azure_use_msi"></a> [tfe\_object\_storage\_azure\_use\_msi](#input\_tfe\_object\_storage\_azure\_use\_msi) | Boolean to use a User-Assigned Identity (MSI) for TFE blob storage account authentication rather than a storage account key. | `bool` | `true` | no |
+| <a name="input_tfe_oidc_hostname_choice"></a> [tfe\_oidc\_hostname\_choice](#input\_tfe\_oidc\_hostname\_choice) | Hostname choice for TFE OIDC integrations. Supported values are `primary` and `secondary`. | `string` | `"primary"` | no |
 | <a name="input_tfe_operational_mode"></a> [tfe\_operational\_mode](#input\_tfe\_operational\_mode) | [Operational mode](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/operation-modes) for TFE. Valid values are `active-active` or `external`. | `string` | `"active-active"` | no |
 | <a name="input_tfe_primary_resource_group_name"></a> [tfe\_primary\_resource\_group\_name](#input\_tfe\_primary\_resource\_group\_name) | Name of existing resource group of TFE deployment in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
 | <a name="input_tfe_primary_storage_account_name"></a> [tfe\_primary\_storage\_account\_name](#input\_tfe\_primary\_storage\_account\_name) | Name of existing TFE storage account in primary region. Only set when `is_secondary_region` is `true`. | `string` | `null` | no |
@@ -337,8 +347,13 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_tfe_redis_use_tls"></a> [tfe\_redis\_use\_tls](#input\_tfe\_redis\_use\_tls) | Boolean to enable TLS for the Redis cache. | `bool` | `true` | no |
 | <a name="input_tfe_run_pipeline_docker_network"></a> [tfe\_run\_pipeline\_docker\_network](#input\_tfe\_run\_pipeline\_docker\_network) | Docker network where the containers that execute Terraform runs will be created. The network must already exist, it will not be created automatically. Leave as `null` to use the default network. | `string` | `null` | no |
 | <a name="input_tfe_run_pipeline_image"></a> [tfe\_run\_pipeline\_image](#input\_tfe\_run\_pipeline\_image) | Name of the Docker image to use for the run pipeline driver. | `string` | `null` | no |
+| <a name="input_tfe_run_task_hostname_choice"></a> [tfe\_run\_task\_hostname\_choice](#input\_tfe\_run\_task\_hostname\_choice) | Hostname choice for TFE run task integrations. Supported values are `primary` and `secondary`. | `string` | `"primary"` | no |
+| <a name="input_tfe_tls_ca_bundle_keyvault_secret_id_secondary"></a> [tfe\_tls\_ca\_bundle\_keyvault\_secret\_id\_secondary](#input\_tfe\_tls\_ca\_bundle\_keyvault\_secret\_id\_secondary) | ID of Key Vault secret containing the secondary TFE TLS custom CA bundle. | `string` | `null` | no |
+| <a name="input_tfe_tls_cert_keyvault_secret_id_secondary"></a> [tfe\_tls\_cert\_keyvault\_secret\_id\_secondary](#input\_tfe\_tls\_cert\_keyvault\_secret\_id\_secondary) | ID of Key Vault secret containing the secondary TFE TLS certificate. | `string` | `null` | no |
 | <a name="input_tfe_tls_enforce"></a> [tfe\_tls\_enforce](#input\_tfe\_tls\_enforce) | Boolean to enforce TLS, Strict-Transport-Security headers, and secure cookies within TFE. | `bool` | `false` | no |
+| <a name="input_tfe_tls_privkey_keyvault_secret_id_secondary"></a> [tfe\_tls\_privkey\_keyvault\_secret\_id\_secondary](#input\_tfe\_tls\_privkey\_keyvault\_secret\_id\_secondary) | ID of Key Vault secret containing the secondary TFE TLS private key. | `string` | `null` | no |
 | <a name="input_tfe_vault_disable_mlock"></a> [tfe\_vault\_disable\_mlock](#input\_tfe\_vault\_disable\_mlock) | Boolean to disable mlock for internal Vault. | `bool` | `false` | no |
+| <a name="input_tfe_vcs_hostname_choice"></a> [tfe\_vcs\_hostname\_choice](#input\_tfe\_vcs\_hostname\_choice) | Hostname choice for TFE VCS integrations. Supported values are `primary` and `secondary`. | `string` | `"primary"` | no |
 | <a name="input_vm_admin_username"></a> [vm\_admin\_username](#input\_vm\_admin\_username) | Admin username for VMs in VMSS. | `string` | `"tfeadmin"` | no |
 | <a name="input_vm_custom_image_name"></a> [vm\_custom\_image\_name](#input\_vm\_custom\_image\_name) | Name of custom VM image to use for VMSS. If not using a custom image, leave this blank. | `string` | `null` | no |
 | <a name="input_vm_custom_image_rg_name"></a> [vm\_custom\_image\_rg\_name](#input\_vm\_custom\_image\_rg\_name) | Name of Resource Group where `vm_custom_image_name` image resides. Only valid if `vm_custom_image_name` is not `null`. | `string` | `null` | no |
@@ -354,9 +369,11 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 
 | Name | Description |
 |------|-------------|
+| <a name="output_secondary_url"></a> [secondary\_url](#output\_secondary\_url) | URL of the optional secondary TFE hostname. |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | FQDN and port of PostgreSQL Flexible Server. |
 | <a name="output_tfe_database_name"></a> [tfe\_database\_name](#output\_tfe\_database\_name) | Name of PostgreSQL Flexible Server database. |
 | <a name="output_tfe_object_storage_azure_account_name"></a> [tfe\_object\_storage\_azure\_account\_name](#output\_tfe\_object\_storage\_azure\_account\_name) | Name of primary TFE Azure Storage Account. |
 | <a name="output_tfe_object_storage_azure_container_name"></a> [tfe\_object\_storage\_azure\_container\_name](#output\_tfe\_object\_storage\_azure\_container\_name) | Name of TFE Azure Storage Container. |
+| <a name="output_tfe_secondary_public_ip_address"></a> [tfe\_secondary\_public\_ip\_address](#output\_tfe\_secondary\_public\_ip\_address) | Public IP address for the managed secondary TFE endpoint when enabled. |
 | <a name="output_url"></a> [url](#output\_url) | URL of TFE application based on `tfe_fqdn` input. |
 <!-- END_TF_DOCS -->

--- a/compute.tf
+++ b/compute.tf
@@ -33,26 +33,32 @@ locals {
   tfe_startup_script_tpl               = var.custom_tfe_startup_script_template != null ? "${path.cwd}/templates/${var.custom_tfe_startup_script_template}" : "${path.module}/templates/tfe_custom_data.sh.tpl"
   redis_port                           = var.tfe_redis_use_tls ? 6380 : 6379
   tfe_object_storage_azure_account_key = var.is_secondary_region ? data.azurerm_storage_account.tfe[0].primary_access_key : azurerm_storage_account.tfe[0].primary_access_key
+  tfe_hostname_secondary_enabled       = var.tfe_hostname_secondary != null
 
   custom_data_args = {
     # Bootstrap
-    tfe_license_keyvault_secret_id             = var.tfe_license_keyvault_secret_id
-    tfe_tls_cert_keyvault_secret_id            = var.tfe_tls_cert_keyvault_secret_id
-    tfe_tls_privkey_keyvault_secret_id         = var.tfe_tls_privkey_keyvault_secret_id
-    tfe_tls_ca_bundle_keyvault_secret_id       = var.tfe_tls_ca_bundle_keyvault_secret_id
-    tfe_encryption_password_keyvault_secret_id = var.tfe_encryption_password_keyvault_secret_id
-    tfe_image_repository_url                   = var.tfe_image_repository_url
-    tfe_image_repository_username              = var.tfe_image_repository_username
-    tfe_image_repository_password              = var.tfe_image_repository_password == null ? "" : var.tfe_image_repository_password
-    tfe_image_name                             = var.tfe_image_name
-    tfe_image_tag                              = var.tfe_image_tag
-    container_runtime                          = var.container_runtime
-    docker_version                             = var.docker_version
-    is_govcloud_region                         = var.is_govcloud_region
+    tfe_license_keyvault_secret_id                 = var.tfe_license_keyvault_secret_id
+    tfe_tls_cert_keyvault_secret_id                = var.tfe_tls_cert_keyvault_secret_id
+    tfe_tls_cert_keyvault_secret_id_secondary      = var.tfe_tls_cert_keyvault_secret_id_secondary == null ? "" : var.tfe_tls_cert_keyvault_secret_id_secondary
+    tfe_tls_privkey_keyvault_secret_id             = var.tfe_tls_privkey_keyvault_secret_id
+    tfe_tls_privkey_keyvault_secret_id_secondary   = var.tfe_tls_privkey_keyvault_secret_id_secondary == null ? "" : var.tfe_tls_privkey_keyvault_secret_id_secondary
+    tfe_tls_ca_bundle_keyvault_secret_id           = var.tfe_tls_ca_bundle_keyvault_secret_id
+    tfe_tls_ca_bundle_keyvault_secret_id_secondary = var.tfe_tls_ca_bundle_keyvault_secret_id_secondary == null ? "" : var.tfe_tls_ca_bundle_keyvault_secret_id_secondary
+    tfe_encryption_password_keyvault_secret_id     = var.tfe_encryption_password_keyvault_secret_id
+    tfe_image_repository_url                       = var.tfe_image_repository_url
+    tfe_image_repository_username                  = var.tfe_image_repository_username
+    tfe_image_repository_password                  = var.tfe_image_repository_password == null ? "" : var.tfe_image_repository_password
+    tfe_image_name                                 = var.tfe_image_name
+    tfe_image_tag                                  = var.tfe_image_tag
+    container_runtime                              = var.container_runtime
+    docker_version                                 = var.docker_version
+    is_govcloud_region                             = var.is_govcloud_region
 
     # https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install/configuration
     # TFE application settings
     tfe_hostname                  = var.tfe_fqdn
+    tfe_hostname_secondary        = var.tfe_hostname_secondary == null ? "" : var.tfe_hostname_secondary
+    tfe_oidc_hostname_choice      = var.tfe_oidc_hostname_choice
     tfe_operational_mode          = var.tfe_operational_mode
     tfe_capacity_concurrency      = var.tfe_capacity_concurrency
     tfe_capacity_cpu              = var.tfe_capacity_cpu
@@ -64,6 +70,8 @@ locals {
     tfe_node_id                   = ""
     tfe_http_port                 = var.tfe_http_port
     tfe_https_port                = var.tfe_https_port
+    tfe_run_task_hostname_choice  = var.tfe_run_task_hostname_choice
+    tfe_vcs_hostname_choice       = var.tfe_vcs_hostname_choice
 
     # Database settings
     tfe_database_host       = "${azurerm_postgresql_flexible_server.tfe.fqdn}:5432"
@@ -89,12 +97,14 @@ locals {
     tfe_redis_password = var.tfe_operational_mode == "active-active" && var.tfe_redis_use_auth ? "${azurerm_redis_cache.tfe[0].primary_access_key}" : ""
 
     # TLS settings
-    tfe_tls_cert_file      = "/etc/ssl/private/terraform-enterprise/cert.pem"
-    tfe_tls_key_file       = "/etc/ssl/private/terraform-enterprise/key.pem"
-    tfe_tls_ca_bundle_file = "/etc/ssl/private/terraform-enterprise/bundle.pem"
-    tfe_tls_enforce        = var.tfe_tls_enforce
-    tfe_tls_ciphers        = ""
-    tfe_tls_version        = ""
+    tfe_tls_cert_file           = "/etc/ssl/private/terraform-enterprise/cert.pem"
+    tfe_tls_cert_file_secondary = "/etc/ssl/private/terraform-enterprise/cert-secondary.pem"
+    tfe_tls_key_file            = "/etc/ssl/private/terraform-enterprise/key.pem"
+    tfe_tls_key_file_secondary  = "/etc/ssl/private/terraform-enterprise/key-secondary.pem"
+    tfe_tls_ca_bundle_file      = "/etc/ssl/private/terraform-enterprise/bundle.pem"
+    tfe_tls_enforce             = var.tfe_tls_enforce
+    tfe_tls_ciphers             = ""
+    tfe_tls_version             = ""
 
     # Observability settings
     tfe_log_forwarding_enabled     = var.tfe_log_forwarding_enabled

--- a/dns.tf
+++ b/dns.tf
@@ -5,7 +5,7 @@
 # DNS zone lookup
 #------------------------------------------------------------------------------
 data "azurerm_dns_zone" "tfe" {
-  count = var.create_tfe_public_dns_record && var.public_dns_zone_name != null ? 1 : 0
+  count = (var.create_tfe_public_dns_record || var.create_tfe_secondary_public_dns_record) && var.public_dns_zone_name != null ? 1 : 0
 
   name                = var.public_dns_zone_name
   resource_group_name = var.public_dns_zone_rg_name
@@ -22,8 +22,9 @@ data "azurerm_private_dns_zone" "tfe" {
 # DNS A record
 #------------------------------------------------------------------------------
 locals {
-  tfe_hostname_public  = var.create_tfe_public_dns_record && var.public_dns_zone_name != null ? trimsuffix(substr(var.tfe_fqdn, 0, length(var.tfe_fqdn) - length(var.public_dns_zone_name) - 1), ".") : var.tfe_fqdn
-  tfe_hostname_private = var.create_tfe_private_dns_record && var.private_dns_zone_name != null ? trim(split(var.private_dns_zone_name, var.tfe_fqdn)[0], ".") : var.tfe_fqdn
+  tfe_hostname_public           = var.create_tfe_public_dns_record && var.public_dns_zone_name != null ? trimsuffix(substr(var.tfe_fqdn, 0, length(var.tfe_fqdn) - length(var.public_dns_zone_name) - 1), ".") : var.tfe_fqdn
+  tfe_hostname_secondary_public = var.create_tfe_secondary_public_dns_record && var.public_dns_zone_name != null ? trimsuffix(substr(var.tfe_hostname_secondary, 0, length(var.tfe_hostname_secondary) - length(var.public_dns_zone_name) - 1), ".") : var.tfe_hostname_secondary
+  tfe_hostname_private          = var.create_tfe_private_dns_record && var.private_dns_zone_name != null ? trim(split(var.private_dns_zone_name, var.tfe_fqdn)[0], ".") : var.tfe_fqdn
 }
 
 resource "azurerm_dns_a_record" "tfe" {
@@ -35,6 +36,17 @@ resource "azurerm_dns_a_record" "tfe" {
   ttl                 = 300
   records             = var.lb_is_internal ? [azurerm_lb.tfe[0].private_ip_address] : null
   target_resource_id  = !var.lb_is_internal ? azurerm_public_ip.tfe_lb[0].id : null
+  tags                = var.common_tags
+}
+
+resource "azurerm_dns_a_record" "tfe_secondary" {
+  count = var.create_tfe_secondary_public_dns_record && var.public_dns_zone_name != null && var.create_tfe_secondary_public_endpoint ? 1 : 0
+
+  name                = local.tfe_hostname_secondary_public
+  resource_group_name = var.public_dns_zone_rg_name
+  zone_name           = data.azurerm_dns_zone.tfe[0].name
+  ttl                 = 300
+  target_resource_id  = azurerm_public_ip.tfe_lb_secondary[0].id
   tags                = var.common_tags
 }
 

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -66,6 +66,26 @@ public_dns_zone_name          = "<example.com>"
 public_dns_zone_rg_name       = "<my-public-dns-zone-resource-group-name>"
 ```
 
+### Secondary hostname and optional managed public endpoint
+
+When your primary TFE hostname should remain private or operator-facing, but integration callbacks such as OIDC, VCS, or run tasks should use a distinct public hostname, set `tfe_hostname_secondary` and the corresponding hostname choice variables. Optionally, the module can add a second Azure public IP and Load Balancer frontend for the secondary hostname and manage the public DNS record in the same zone.
+
+```hcl
+tfe_hostname_secondary              = "tfe-integrations.azure.example.com"
+tfe_oidc_hostname_choice            = "secondary"
+tfe_vcs_hostname_choice             = "secondary"
+tfe_run_task_hostname_choice        = "secondary"
+tfe_tls_cert_keyvault_secret_id_secondary    = "<https://tfe-secondary-cert-secret-id>"
+tfe_tls_privkey_keyvault_secret_id_secondary = "<https://tfe-secondary-key-secret-id>"
+tfe_tls_ca_bundle_keyvault_secret_id_secondary = "<https://tfe-secondary-ca-secret-id>"
+create_tfe_secondary_public_endpoint   = true
+create_tfe_secondary_public_dns_record = true
+public_dns_zone_name                   = "azure.example.com"
+public_dns_zone_rg_name                = "<my-public-dns-zone-resource-group-name>"
+```
+
+If you want the secondary hostname to reuse an existing, externally managed endpoint, leave `create_tfe_secondary_public_endpoint = false` and manage the DNS target outside this module.
+
 ## Log forwarding
 
 The following variables may be set to enable TFE log forwarding (via Fluent Bit). The destinations supported at this time are an Azure Log Analytics Workspace or a custom Fluent Bit configuration, either of which would need to exist as a prerequisite.

--- a/docs/tfe-cert-rotation.md
+++ b/docs/tfe-cert-rotation.md
@@ -1,6 +1,6 @@
 # TFE Certificate Rotation
 
-A required prerequisite to deploying this module is storing a base64-encoded string of your TFE TLS certificate file (PEM format) and a base64-encoded string of your TFE TLS certificate private key file (PEM format) in an Azure Key Vault for bootstrapping purposes. The steps to rotate these certificates are simply to update these two secrets within your "bootstrap" Azure Key Vault, update the applicable module input variables with the new Key Vault secret identifiers, and then replace/re-image the VM(s) within your TFE virtual machine scale set (VMSS).
+A required prerequisite to deploying this module is storing a base64-encoded string of your TFE TLS certificate file (PEM format) and a base64-encoded string of your TFE TLS certificate private key file (PEM format) in an Azure Key Vault for bootstrapping purposes. The steps to rotate these certificates are simply to update these secrets within your "bootstrap" Azure Key Vault, update the applicable module input variables with the new Key Vault secret identifiers, and then replace/re-image the VM(s) within your TFE virtual machine scale set (VMSS). If you use `tfe_hostname_secondary`, repeat the same process for the `*_secondary` TLS secret inputs as well.
 
 ## Procedure
 
@@ -46,8 +46,10 @@ A required prerequisite to deploying this module is storing a base64-encoded str
 1. Update the following input variable values within your `terraform.tfvars` file with the new Key Vault secret identifiers:
 
     ```hcl
-    tfe_tls_cert_keyvault_secret_id    = "<https://new-tfe-cert-key-vault-secret-identifier>"
-    tfe_tls_privkey_keyvault_secret_id = "<https://new-tfe-privkey-key-vault-secret-identifier>"
+    tfe_tls_cert_keyvault_secret_id              = "<https://new-tfe-cert-key-vault-secret-identifier>"
+    tfe_tls_privkey_keyvault_secret_id           = "<https://new-tfe-privkey-key-vault-secret-identifier>"
+    tfe_tls_cert_keyvault_secret_id_secondary    = "<https://new-tfe-secondary-cert-key-vault-secret-identifier>"    # optional
+    tfe_tls_privkey_keyvault_secret_id_secondary = "<https://new-tfe-secondary-privkey-key-vault-secret-identifier>" # optional
     ```
 
 1. During a maintenance window, run `terraform apply` against your root Terraform configuration that manages your TFE deployment.

--- a/docs/tfe-config-settings.md
+++ b/docs/tfe-config-settings.md
@@ -13,3 +13,16 @@ The [Terraform Enterprise Flexible Deployment Options configuration reference](h
 Within the [compute.tf](../compute.tf) file, you will see a `locals` block with a map inside of it called `custom_data_args`. Almost all of the TFE configuration settings are passed from here into the [tfe_custom_data.sh](../templates/tfe_custom_data.sh.tpl) script.
 
 Within the [tfe_custom_data.sh](../templates/tfe_custom_data.sh.tpl) script there is a function named `generate_tfe_docker_compose` that is responsible for receiving all of those inputs and dynamically generating the `docker-compose.yaml` file. After a successful install process, this can be found on your TFE VM(s) within `/etc/tfe/docker-compose.yaml`.
+
+## Secondary hostname support
+
+This module can also render the TFE secondary-hostname settings when `tfe_hostname_secondary` is set. The bootstrap template writes the following configuration values into the runtime manifest for Docker and Podman:
+
+- `TFE_HOSTNAME_SECONDARY`
+- `TFE_OIDC_HOSTNAME_CHOICE`
+- `TFE_VCS_HOSTNAME_CHOICE`
+- `TFE_RUN_TASK_HOSTNAME_CHOICE`
+- `TFE_TLS_CERT_FILE_SECONDARY`
+- `TFE_TLS_KEY_FILE_SECONDARY`
+
+The secondary certificate, private key, and CA bundle are retrieved from Azure Key Vault using the `*_secondary` secret ID inputs and the secondary CA bundle is appended to the primary bundle so both trust chains are available to TFE.

--- a/examples/main/README.md
+++ b/examples/main/README.md
@@ -43,6 +43,12 @@ Supported values:
 
 We recommend deploying an internal load balancer unless you have a specific use case where your TFE users/clients or VCS need to be able to reach your TFE instance from the Internet.
 
+#### Secondary hostname and managed public endpoint
+
+**Input variables:** `tfe_hostname_secondary`, `create_tfe_secondary_public_endpoint`, `create_tfe_secondary_public_dns_record`
+
+Set `tfe_hostname_secondary` when OIDC, VCS, or run task callbacks should use a different hostname than the primary `tfe_fqdn`. When you also set `create_tfe_secondary_public_endpoint = true`, the module adds a second public IP and Azure Load Balancer frontend on port `443` for that hostname. If you already manage the secondary DNS name outside the module, you can leave the managed endpoint disabled and point the hostname at your preferred IP yourself.
+
 ### Log forwarding
 
 **Input variable:** `tfe_log_forwarding_enabled` (bool)

--- a/examples/main/main.tf
+++ b/examples/main/main.tf
@@ -26,25 +26,32 @@ module "tfe" {
   is_govcloud_region    = var.is_govcloud_region
 
   # --- Bootstrap --- #
-  bootstrap_keyvault_name                    = var.bootstrap_keyvault_name
-  bootstrap_keyvault_rg_name                 = var.bootstrap_keyvault_rg_name
-  tfe_license_keyvault_secret_id             = var.tfe_license_keyvault_secret_id
-  tfe_tls_cert_keyvault_secret_id            = var.tfe_tls_cert_keyvault_secret_id
-  tfe_tls_privkey_keyvault_secret_id         = var.tfe_tls_privkey_keyvault_secret_id
-  tfe_tls_ca_bundle_keyvault_secret_id       = var.tfe_tls_ca_bundle_keyvault_secret_id
-  tfe_encryption_password_keyvault_secret_id = var.tfe_encryption_password_keyvault_secret_id
+  bootstrap_keyvault_name                        = var.bootstrap_keyvault_name
+  bootstrap_keyvault_rg_name                     = var.bootstrap_keyvault_rg_name
+  tfe_license_keyvault_secret_id                 = var.tfe_license_keyvault_secret_id
+  tfe_tls_cert_keyvault_secret_id                = var.tfe_tls_cert_keyvault_secret_id
+  tfe_tls_cert_keyvault_secret_id_secondary      = var.tfe_tls_cert_keyvault_secret_id_secondary
+  tfe_tls_privkey_keyvault_secret_id             = var.tfe_tls_privkey_keyvault_secret_id
+  tfe_tls_privkey_keyvault_secret_id_secondary   = var.tfe_tls_privkey_keyvault_secret_id_secondary
+  tfe_tls_ca_bundle_keyvault_secret_id           = var.tfe_tls_ca_bundle_keyvault_secret_id
+  tfe_tls_ca_bundle_keyvault_secret_id_secondary = var.tfe_tls_ca_bundle_keyvault_secret_id_secondary
+  tfe_encryption_password_keyvault_secret_id     = var.tfe_encryption_password_keyvault_secret_id
 
   # --- TFE config settings --- #
-  tfe_fqdn                 = var.tfe_fqdn
-  tfe_image_tag            = var.tfe_image_tag
-  tfe_hairpin_addressing   = var.tfe_hairpin_addressing
-  tfe_capacity_concurrency = var.tfe_capacity_concurrency
-  tfe_capacity_cpu         = var.tfe_capacity_cpu
-  tfe_capacity_memory      = var.tfe_capacity_memory
-  tfe_metrics_enable       = var.tfe_metrics_enable
-  tfe_metrics_http_port    = var.tfe_metrics_http_port
-  tfe_metrics_https_port   = var.tfe_metrics_https_port
-  tfe_operational_mode     = var.tfe_operational_mode
+  tfe_fqdn                     = var.tfe_fqdn
+  tfe_hostname_secondary       = var.tfe_hostname_secondary
+  tfe_oidc_hostname_choice     = var.tfe_oidc_hostname_choice
+  tfe_vcs_hostname_choice      = var.tfe_vcs_hostname_choice
+  tfe_run_task_hostname_choice = var.tfe_run_task_hostname_choice
+  tfe_image_tag                = var.tfe_image_tag
+  tfe_hairpin_addressing       = var.tfe_hairpin_addressing
+  tfe_capacity_concurrency     = var.tfe_capacity_concurrency
+  tfe_capacity_cpu             = var.tfe_capacity_cpu
+  tfe_capacity_memory          = var.tfe_capacity_memory
+  tfe_metrics_enable           = var.tfe_metrics_enable
+  tfe_metrics_http_port        = var.tfe_metrics_http_port
+  tfe_metrics_https_port       = var.tfe_metrics_https_port
+  tfe_operational_mode         = var.tfe_operational_mode
 
   # --- Networking --- #
   vnet_id         = var.vnet_id
@@ -56,9 +63,14 @@ module "tfe" {
   redis_subnet_id = var.redis_subnet_id
 
   # --- DNS (optional) --- #
-  create_tfe_private_dns_record = var.create_tfe_private_dns_record
-  private_dns_zone_name         = var.private_dns_zone_name
-  private_dns_zone_rg_name      = var.private_dns_zone_rg_name
+  create_tfe_public_dns_record           = var.create_tfe_public_dns_record
+  public_dns_zone_name                   = var.public_dns_zone_name
+  public_dns_zone_rg_name                = var.public_dns_zone_rg_name
+  create_tfe_secondary_public_endpoint   = var.create_tfe_secondary_public_endpoint
+  create_tfe_secondary_public_dns_record = var.create_tfe_secondary_public_dns_record
+  create_tfe_private_dns_record          = var.create_tfe_private_dns_record
+  private_dns_zone_name                  = var.private_dns_zone_name
+  private_dns_zone_rg_name               = var.private_dns_zone_rg_name
 
   # --- Compute --- #
   vmss_instance_count = var.vmss_instance_count

--- a/examples/main/terraform.tfvars.example
+++ b/examples/main/terraform.tfvars.example
@@ -15,12 +15,19 @@ bootstrap_keyvault_name                    = "<bootstrap-keyvault-name>"
 bootstrap_keyvault_rg_name                 = "<bootstrap-keyvault-resource-group-name>"
 tfe_license_keyvault_secret_id             = "<https://tfe-license-keyvault-secret-id>"
 tfe_tls_cert_keyvault_secret_id            = "<https://tfe-cert-keyvault-secret-id>"
+tfe_tls_cert_keyvault_secret_id_secondary  = null
 tfe_tls_privkey_keyvault_secret_id         = "<https://tfe-private-key-keyvault-secret-id>"
+tfe_tls_privkey_keyvault_secret_id_secondary = null
 tfe_tls_ca_bundle_keyvault_secret_id       = "<https://tfe-custom-ca-bundle-keyvault-secret-id>"
+tfe_tls_ca_bundle_keyvault_secret_id_secondary = null
 tfe_encryption_password_keyvault_secret_id = "<https://tfe-encryption-password-keyvault-secret-id>"
 
 # --- TFE config settings --- #
 tfe_fqdn                 = "<tfe.azure.example.com>"
+tfe_hostname_secondary   = null
+tfe_oidc_hostname_choice = "<primary>"
+tfe_vcs_hostname_choice  = "<primary>"
+tfe_run_task_hostname_choice = "<primary>"
 tfe_image_tag            = "<v202502-1>"     # TFE version, refer to https://developer.hashicorp.com/terraform/enterprise/releases
 tfe_operational_mode     = "<active-active>" # `active-active` or `external`. refer to https://developer.hashicorp.com/validated-designs/terraform-solution-design-guides-terraform-enterprise/architecture#deployment-topologies
 tfe_capacity_concurrency = <10>              # Maximum number of Terraform runs that can execute concurrently on each Terraform Enterprise node. Defaults to 10.
@@ -40,6 +47,11 @@ db_subnet_id    = "<tfe-database-subnet-id>"
 redis_subnet_id = "<tfe-redis-subnet-id>"
 
 # --- DNS (optional) --- #
+create_tfe_public_dns_record           = <false>
+public_dns_zone_name                   = null
+public_dns_zone_rg_name                = null
+create_tfe_secondary_public_endpoint   = <false>
+create_tfe_secondary_public_dns_record = <false>
 create_tfe_private_dns_record = <true>
 private_dns_zone_name         = "<example.com>"
 private_dns_zone_rg_name      = "<private-dns-zone-resource-group-name>"

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -108,14 +108,47 @@ variable "tfe_tls_cert_keyvault_secret_id" {
   description = "ID of Key Vault secret containing TFE TLS certificate."
 }
 
+variable "tfe_tls_cert_keyvault_secret_id_secondary" {
+  type        = string
+  description = "ID of Key Vault secret containing the secondary TFE TLS certificate."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_cert_keyvault_secret_id_secondary != null : var.tfe_tls_cert_keyvault_secret_id_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be null otherwise."
+  }
+}
+
 variable "tfe_tls_privkey_keyvault_secret_id" {
   type        = string
   description = "ID of Key Vault secret containing TFE TLS private key."
 }
 
+variable "tfe_tls_privkey_keyvault_secret_id_secondary" {
+  type        = string
+  description = "ID of Key Vault secret containing the secondary TFE TLS private key."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_privkey_keyvault_secret_id_secondary != null : var.tfe_tls_privkey_keyvault_secret_id_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be null otherwise."
+  }
+}
+
 variable "tfe_tls_ca_bundle_keyvault_secret_id" {
   type        = string
   description = "ID of Key Vault secret containing TFE TLS custom CA bundle."
+}
+
+variable "tfe_tls_ca_bundle_keyvault_secret_id_secondary" {
+  type        = string
+  description = "ID of Key Vault secret containing the secondary TFE TLS custom CA bundle."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_ca_bundle_keyvault_secret_id_secondary != null : var.tfe_tls_ca_bundle_keyvault_secret_id_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be null otherwise."
+  }
 }
 
 variable "tfe_encryption_password_keyvault_secret_id" {
@@ -164,6 +197,60 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name of TFE instance. This name should resolve to the load balancer IP address and will be what clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Secondary externally resolvable fully qualified domain name for TFE integration traffic such as OIDC, VCS, or run tasks."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE OIDC integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_oidc_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_oidc_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_oidc_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE VCS integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_vcs_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_vcs_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_vcs_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE run task integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_run_task_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_run_task_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_run_task_hostname_choice` is `secondary`."
+  }
 }
 
 variable "tfe_capacity_concurrency" {
@@ -350,8 +437,8 @@ variable "public_dns_zone_name" {
   default     = null
 
   validation {
-    condition     = var.create_tfe_public_dns_record ? var.public_dns_zone_name != null : true
-    error_message = "A value is required when `create_tfe_public_dns_record` is `true`."
+    condition     = var.create_tfe_public_dns_record || var.create_tfe_secondary_public_dns_record ? var.public_dns_zone_name != null : true
+    error_message = "A value is required when either public DNS record toggle is true."
   }
 }
 
@@ -363,6 +450,28 @@ variable "public_dns_zone_rg_name" {
   validation {
     condition     = var.public_dns_zone_name != null ? var.public_dns_zone_rg_name != null : true
     error_message = "A value is required when `public_dns_zone_name` is not `null`."
+  }
+}
+
+variable "create_tfe_secondary_public_endpoint" {
+  type        = bool
+  description = "Boolean to create a managed public Azure load balancer frontend and public IP for `tfe_hostname_secondary`."
+  default     = false
+
+  validation {
+    condition     = var.create_tfe_secondary_public_endpoint ? var.tfe_hostname_secondary != null && var.create_lb : true
+    error_message = "`tfe_hostname_secondary` must be set and `create_lb` must be true when `create_tfe_secondary_public_endpoint` is true."
+  }
+}
+
+variable "create_tfe_secondary_public_dns_record" {
+  type        = bool
+  description = "Boolean to create a public Azure DNS record for `tfe_hostname_secondary`."
+  default     = false
+
+  validation {
+    condition     = var.create_tfe_secondary_public_dns_record ? var.create_tfe_secondary_public_endpoint : true
+    error_message = "`create_tfe_secondary_public_endpoint` must be true when `create_tfe_secondary_public_dns_record` is true."
   }
 }
 

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -20,11 +20,51 @@ resource "azurerm_public_ip" "tfe_lb" {
   )
 }
 
+resource "azurerm_public_ip" "tfe_lb_secondary" {
+  count = var.create_lb && var.create_tfe_secondary_public_endpoint ? 1 : 0
+
+  name                = "${var.friendly_name_prefix}-tfe-lb-secondary-ip"
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  zones               = var.availability_zones
+  sku                 = "Standard"
+  allocation_method   = "Static"
+
+  tags = merge(
+    { "Name" = "${var.friendly_name_prefix}-tfe-lb-secondary-ip" },
+    var.common_tags
+  )
+}
+
 #------------------------------------------------------------------------------
 # Azure load balancer
 #------------------------------------------------------------------------------
 locals {
-  lb_frontend_name_suffix = var.lb_is_internal ? "internal" : "external"
+  lb_frontend_name_suffix        = var.lb_is_internal ? "internal" : "external"
+  tfe_lb_frontend_name           = "tfe-frontend-${local.lb_frontend_name_suffix}"
+  tfe_lb_secondary_frontend_name = "tfe-frontend-secondary-external"
+  lb_frontend_ip_configurations = concat(
+    [
+      {
+        name                          = local.tfe_lb_frontend_name
+        zones                         = var.lb_is_internal ? var.availability_zones : null
+        public_ip_address_id          = var.create_lb && !var.lb_is_internal ? azurerm_public_ip.tfe_lb[0].id : null
+        subnet_id                     = var.lb_is_internal ? var.lb_subnet_id : null
+        private_ip_address_allocation = var.lb_is_internal ? "Static" : null
+        private_ip_address            = var.lb_is_internal ? var.lb_private_ip : null
+      }
+    ],
+    var.create_tfe_secondary_public_endpoint ? [
+      {
+        name                          = local.tfe_lb_secondary_frontend_name
+        zones                         = null
+        public_ip_address_id          = azurerm_public_ip.tfe_lb_secondary[0].id
+        subnet_id                     = null
+        private_ip_address_allocation = null
+        private_ip_address            = null
+      }
+    ] : []
+  )
 }
 
 resource "azurerm_lb" "tfe" {
@@ -36,13 +76,17 @@ resource "azurerm_lb" "tfe" {
   sku                 = "Standard"
   sku_tier            = "Regional"
 
-  frontend_ip_configuration {
-    name                          = "tfe-frontend-${local.lb_frontend_name_suffix}"
-    zones                         = var.lb_is_internal ? var.availability_zones : null
-    public_ip_address_id          = !var.lb_is_internal ? azurerm_public_ip.tfe_lb[0].id : null
-    subnet_id                     = var.lb_is_internal ? var.lb_subnet_id : null
-    private_ip_address_allocation = var.lb_is_internal ? "Static" : null
-    private_ip_address            = var.lb_is_internal ? var.lb_private_ip : null
+  dynamic "frontend_ip_configuration" {
+    for_each = local.lb_frontend_ip_configurations
+
+    content {
+      name                          = frontend_ip_configuration.value.name
+      zones                         = frontend_ip_configuration.value.zones
+      public_ip_address_id          = frontend_ip_configuration.value.public_ip_address_id
+      subnet_id                     = frontend_ip_configuration.value.subnet_id
+      private_ip_address_allocation = frontend_ip_configuration.value.private_ip_address_allocation
+      private_ip_address            = frontend_ip_configuration.value.private_ip_address
+    }
   }
 
   tags = merge(
@@ -77,7 +121,20 @@ resource "azurerm_lb_rule" "tfe" {
   loadbalancer_id                = azurerm_lb.tfe[0].id
   probe_id                       = azurerm_lb_probe.tfe[0].id
   protocol                       = "Tcp"
-  frontend_ip_configuration_name = azurerm_lb.tfe[0].frontend_ip_configuration[0].name
+  frontend_ip_configuration_name = local.tfe_lb_frontend_name
+  frontend_port                  = 443
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.tfe_servers[0].id]
+  backend_port                   = 443
+}
+
+resource "azurerm_lb_rule" "tfe_secondary" {
+  count = var.create_lb && var.create_tfe_secondary_public_endpoint ? 1 : 0
+
+  name                           = "${var.friendly_name_prefix}-tfe-lb-rule-secondary-app"
+  loadbalancer_id                = azurerm_lb.tfe[0].id
+  probe_id                       = azurerm_lb_probe.tfe[0].id
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = local.tfe_lb_secondary_frontend_name
   frontend_port                  = 443
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.tfe_servers[0].id]
   backend_port                   = 443

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,16 @@ output "url" {
   description = "URL of TFE application based on `tfe_fqdn` input."
 }
 
+output "secondary_url" {
+  value       = var.tfe_hostname_secondary != null ? "https://${var.tfe_hostname_secondary}" : null
+  description = "URL of the optional secondary TFE hostname."
+}
+
+output "tfe_secondary_public_ip_address" {
+  value       = try(azurerm_public_ip.tfe_lb_secondary[0].ip_address, null)
+  description = "Public IP address for the managed secondary TFE endpoint when enabled."
+}
+
 #------------------------------------------------------------------------------
 # Database
 #------------------------------------------------------------------------------
@@ -34,4 +44,3 @@ output "tfe_object_storage_azure_container_name" {
   value       = try(azurerm_storage_container.tfe[0].name, null)
   description = "Name of TFE Azure Storage Container."
 }
-

--- a/specs/secondary-hostname/plan.md
+++ b/specs/secondary-hostname/plan.md
@@ -1,0 +1,13 @@
+# Plan: Secondary hostname support
+
+## Implementation approach
+
+1. Add inputs for the secondary hostname, hostname-choice settings, and secondary TLS Key Vault secrets.
+2. Extend `compute.tf` and `templates/tfe_custom_data.sh.tpl` to retrieve secondary TLS files and configure the TFE runtime.
+3. Add optional Azure public-IP/load-balancer/DNS support for a managed secondary hostname path.
+4. Update examples, outputs, and docs.
+
+## Azure-specific notes
+
+- The cleanest Azure shape is to reuse the existing Standard Load Balancer with an additional public frontend and rule rather than creating an entirely separate load balancer.
+- DNS should stay optional so callers can bring their own external hostname path.

--- a/specs/secondary-hostname/spec.md
+++ b/specs/secondary-hostname/spec.md
@@ -1,0 +1,21 @@
+# Spec: Secondary hostname support
+
+## Summary
+
+Port secondary hostname support into the Azure TFE VM module so external integrations can use a managed or caller-managed secondary hostname path.
+
+## Requirements
+
+1. The module must support configuring `TFE_HOSTNAME_SECONDARY` and the hostname-choice settings for OIDC, VCS, and run tasks.
+2. The module must support separate secondary TLS materials from Azure Key Vault.
+3. The module must support an optional managed Azure public endpoint and public DNS record for the secondary hostname.
+4. The module must preserve the existing primary hostname path and keep secondary support optional.
+5. Docs and examples must explain the managed and caller-managed secondary-hostname modes.
+
+## Acceptance criteria
+
+- New secondary-hostname and secondary-TLS variables are added to module and example inputs.
+- The startup template writes the secondary hostname and TLS env vars when configured.
+- Azure networking resources support an optional secondary public entry point.
+- Outputs and docs describe the secondary URL and DNS/TLS prerequisites.
+- The module validates from the root and `examples/main`.

--- a/specs/secondary-hostname/tasks.md
+++ b/specs/secondary-hostname/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Secondary hostname support
+
+1. Add secondary-hostname and TLS inputs in `variables.tf` and `compute.tf`.
+2. Update `templates/tfe_custom_data.sh.tpl`, `load_balancer.tf`, `dns.tf`, and `outputs.tf`.
+3. Update `examples/main/*`, `README.md`, and docs.
+4. Run `task test` and `task terraform-docs`.

--- a/templates/tfe_custom_data.sh.tpl
+++ b/templates/tfe_custom_data.sh.tpl
@@ -124,6 +124,17 @@ function retrieve_certs_from_key_vault {
   az keyvault secret show --id "${tfe_tls_privkey_keyvault_secret_id}" --query value --output tsv | base64 -d > $TFE_TLS_CERTS_DIR/key.pem
   log "INFO" "Retrieving TLS CA bundle '${tfe_tls_ca_bundle_keyvault_secret_id}' from Key Vault."
   az keyvault secret show --id "${tfe_tls_ca_bundle_keyvault_secret_id}" --query value --output tsv | base64 -d > $TFE_TLS_CERTS_DIR/bundle.pem
+
+  if [[ -n "${tfe_hostname_secondary}" ]]; then
+    log "INFO" "Retrieving secondary TLS certificate '${tfe_tls_cert_keyvault_secret_id_secondary}' from Key Vault."
+    az keyvault secret show --id "${tfe_tls_cert_keyvault_secret_id_secondary}" --query value --output tsv | base64 -d > $TFE_TLS_CERTS_DIR/cert-secondary.pem
+    log "INFO" "Retrieving secondary TLS private key '${tfe_tls_privkey_keyvault_secret_id_secondary}' from Key Vault."
+    az keyvault secret show --id "${tfe_tls_privkey_keyvault_secret_id_secondary}" --query value --output tsv | base64 -d > $TFE_TLS_CERTS_DIR/key-secondary.pem
+    log "INFO" "Retrieving secondary TLS CA bundle '${tfe_tls_ca_bundle_keyvault_secret_id_secondary}' from Key Vault."
+    az keyvault secret show --id "${tfe_tls_ca_bundle_keyvault_secret_id_secondary}" --query value --output tsv | base64 -d > $TFE_TLS_CERTS_DIR/bundle-secondary.pem
+    printf "\n" >> $TFE_TLS_CERTS_DIR/bundle.pem
+    cat $TFE_TLS_CERTS_DIR/bundle-secondary.pem >> $TFE_TLS_CERTS_DIR/bundle.pem
+  fi
 }
 
 function retrieve_license_from_key_vault {
@@ -174,6 +185,12 @@ services:
       TFE_NODE_ID: ${tfe_node_id}
       TFE_HTTP_PORT: ${tfe_http_port}
       TFE_HTTPS_PORT: ${tfe_https_port}
+%{ if tfe_hostname_secondary != "" ~}
+      TFE_HOSTNAME_SECONDARY: ${tfe_hostname_secondary}
+      TFE_OIDC_HOSTNAME_CHOICE: ${tfe_oidc_hostname_choice}
+      TFE_VCS_HOSTNAME_CHOICE: ${tfe_vcs_hostname_choice}
+      TFE_RUN_TASK_HOSTNAME_CHOICE: ${tfe_run_task_hostname_choice}
+%{ endif ~}
 
       # Database settings
       TFE_DATABASE_HOST: ${tfe_database_host}
@@ -209,6 +226,10 @@ services:
       TFE_TLS_CERT_FILE: ${tfe_tls_cert_file}
       TFE_TLS_KEY_FILE: ${tfe_tls_key_file}
       TFE_TLS_CA_BUNDLE_FILE: ${tfe_tls_ca_bundle_file}
+%{ if tfe_hostname_secondary != "" ~}
+      TFE_TLS_CERT_FILE_SECONDARY: ${tfe_tls_cert_file_secondary}
+      TFE_TLS_KEY_FILE_SECONDARY: ${tfe_tls_key_file_secondary}
+%{ endif ~}
       TFE_TLS_CIPHERS: ${tfe_tls_ciphers}
       TFE_TLS_ENFORCE: ${tfe_tls_enforce}
       TFE_TLS_VERSION: ${tfe_tls_version}
@@ -237,6 +258,9 @@ services:
 %{ if tfe_hairpin_addressing ~}
     extra_hosts:
       - ${tfe_hostname}:$VM_PRIVATE_IP
+%{ if tfe_hostname_secondary != "" ~}
+      - ${tfe_hostname_secondary}:$VM_PRIVATE_IP
+%{ endif ~}
 %{ endif ~}
     cap_add:
       - IPC_LOCK
@@ -295,6 +319,9 @@ spec:
     - ip: $VM_PRIVATE_IP
       hostnames:
         - "${tfe_hostname}"
+%{ if tfe_hostname_secondary != "" ~}
+        - "${tfe_hostname_secondary}"
+%{ endif ~}
 %{ endif ~}
   containers:
   - env:
@@ -329,6 +356,16 @@ spec:
       value: ${tfe_http_port}
     - name: "TFE_HTTPS_PORT"
       value: ${tfe_https_port}
+%{ if tfe_hostname_secondary != "" ~}
+    - name: "TFE_HOSTNAME_SECONDARY"
+      value: ${tfe_hostname_secondary}
+    - name: "TFE_OIDC_HOSTNAME_CHOICE"
+      value: ${tfe_oidc_hostname_choice}
+    - name: "TFE_VCS_HOSTNAME_CHOICE"
+      value: ${tfe_vcs_hostname_choice}
+    - name: "TFE_RUN_TASK_HOSTNAME_CHOICE"
+      value: ${tfe_run_task_hostname_choice}
+%{ endif ~}
 
     # Database settings
     - name: "TFE_DATABASE_HOST"
@@ -384,6 +421,12 @@ spec:
       value: ${tfe_tls_key_file}
     - name: "TFE_TLS_CA_BUNDLE_FILE"
       value: ${tfe_tls_ca_bundle_file}
+%{ if tfe_hostname_secondary != "" ~}
+    - name: "TFE_TLS_CERT_FILE_SECONDARY"
+      value: ${tfe_tls_cert_file_secondary}
+    - name: "TFE_TLS_KEY_FILE_SECONDARY"
+      value: ${tfe_tls_key_file_secondary}
+%{ endif ~}
     - name: "TFE_TLS_CIPHERS"
       value: ${tfe_tls_ciphers}
     - name: "TFE_TLS_ENFORCE"

--- a/variables.tf
+++ b/variables.tf
@@ -108,14 +108,47 @@ variable "tfe_tls_cert_keyvault_secret_id" {
   description = "ID of Key Vault secret containing TFE TLS certificate."
 }
 
+variable "tfe_tls_cert_keyvault_secret_id_secondary" {
+  type        = string
+  description = "ID of Key Vault secret containing the secondary TFE TLS certificate."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_cert_keyvault_secret_id_secondary != null : var.tfe_tls_cert_keyvault_secret_id_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be null otherwise."
+  }
+}
+
 variable "tfe_tls_privkey_keyvault_secret_id" {
   type        = string
   description = "ID of Key Vault secret containing TFE TLS private key."
 }
 
+variable "tfe_tls_privkey_keyvault_secret_id_secondary" {
+  type        = string
+  description = "ID of Key Vault secret containing the secondary TFE TLS private key."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_privkey_keyvault_secret_id_secondary != null : var.tfe_tls_privkey_keyvault_secret_id_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be null otherwise."
+  }
+}
+
 variable "tfe_tls_ca_bundle_keyvault_secret_id" {
   type        = string
   description = "ID of Key Vault secret containing TFE TLS custom CA bundle."
+}
+
+variable "tfe_tls_ca_bundle_keyvault_secret_id_secondary" {
+  type        = string
+  description = "ID of Key Vault secret containing the secondary TFE TLS custom CA bundle."
+  default     = null
+
+  validation {
+    condition     = var.tfe_hostname_secondary != null ? var.tfe_tls_ca_bundle_keyvault_secret_id_secondary != null : var.tfe_tls_ca_bundle_keyvault_secret_id_secondary == null
+    error_message = "Value must be set when `tfe_hostname_secondary` is configured and must be null otherwise."
+  }
 }
 
 variable "tfe_encryption_password_keyvault_secret_id" {
@@ -164,6 +197,60 @@ variable "tfe_image_repository_password" {
 variable "tfe_fqdn" {
   type        = string
   description = "Fully qualified domain name of TFE instance. This name should resolve to the load balancer IP address and will be what clients use to access TFE."
+}
+
+variable "tfe_hostname_secondary" {
+  type        = string
+  description = "Secondary externally resolvable fully qualified domain name for TFE integration traffic such as OIDC, VCS, or run tasks."
+  default     = null
+}
+
+variable "tfe_oidc_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE OIDC integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_oidc_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_oidc_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_oidc_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_vcs_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE VCS integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_vcs_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_vcs_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_vcs_hostname_choice` is `secondary`."
+  }
+}
+
+variable "tfe_run_task_hostname_choice" {
+  type        = string
+  description = "Hostname choice for TFE run task integrations. Supported values are `primary` and `secondary`."
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "secondary"], var.tfe_run_task_hostname_choice)
+    error_message = "Supported values are `primary` or `secondary`."
+  }
+
+  validation {
+    condition     = var.tfe_run_task_hostname_choice == "secondary" ? var.tfe_hostname_secondary != null : true
+    error_message = "`tfe_hostname_secondary` must be set when `tfe_run_task_hostname_choice` is `secondary`."
+  }
 }
 
 variable "tfe_capacity_concurrency" {
@@ -350,8 +437,8 @@ variable "public_dns_zone_name" {
   default     = null
 
   validation {
-    condition     = var.create_tfe_public_dns_record ? var.public_dns_zone_name != null : true
-    error_message = "A value is required when `create_tfe_public_dns_record` is `true`."
+    condition     = var.create_tfe_public_dns_record || var.create_tfe_secondary_public_dns_record ? var.public_dns_zone_name != null : true
+    error_message = "A value is required when either public DNS record toggle is true."
   }
 }
 
@@ -363,6 +450,28 @@ variable "public_dns_zone_rg_name" {
   validation {
     condition     = var.public_dns_zone_name != null ? var.public_dns_zone_rg_name != null : true
     error_message = "A value is required when `public_dns_zone_name` is not `null`."
+  }
+}
+
+variable "create_tfe_secondary_public_endpoint" {
+  type        = bool
+  description = "Boolean to create a managed public Azure load balancer frontend and public IP for `tfe_hostname_secondary`."
+  default     = false
+
+  validation {
+    condition     = var.create_tfe_secondary_public_endpoint ? var.tfe_hostname_secondary != null && var.create_lb : true
+    error_message = "`tfe_hostname_secondary` must be set and `create_lb` must be true when `create_tfe_secondary_public_endpoint` is true."
+  }
+}
+
+variable "create_tfe_secondary_public_dns_record" {
+  type        = bool
+  description = "Boolean to create a public Azure DNS record for `tfe_hostname_secondary`."
+  default     = false
+
+  validation {
+    condition     = var.create_tfe_secondary_public_dns_record ? var.create_tfe_secondary_public_endpoint : true
+    error_message = "`create_tfe_secondary_public_endpoint` must be true when `create_tfe_secondary_public_dns_record` is true."
   }
 }
 


### PR DESCRIPTION
This pull request adds support for configuring an optional secondary public endpoint and hostname for Terraform Enterprise (TFE) deployments, mainly to facilitate integration traffic (such as OIDC, VCS, or run tasks) via a separate FQDN and public IP. It includes updates to documentation, variables, outputs, and resource definitions to enable and document this feature.

**Key changes:**

### Secondary Endpoint and Hostname Support

* Added new variables to support a secondary FQDN (`tfe_hostname_secondary`), public IP, and DNS record for integration traffic, along with corresponding Key Vault secrets for TLS configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R273-R274) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R327) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R350-R356) [[6]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR36-R46) [[7]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR60-R61) [[8]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR73-R74) [[9]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR101-R103)

### Azure Resource Definitions

* Introduced new Azure resources for the secondary endpoint, including `azurerm_dns_a_record.tfe_secondary`, `azurerm_public_ip.tfe_lb_secondary`, and `azurerm_lb_rule.tfe_secondary`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R203) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R220) [[3]](diffhunk://#diff-d160bcd3ef13731ac5d7aa43f0c1e76f5635c0a2284a2af2dd35c86a124aee5dL8-R8) [[4]](diffhunk://#diff-d160bcd3ef13731ac5d7aa43f0c1e76f5635c0a2284a2af2dd35c86a124aee5dR26) [[5]](diffhunk://#diff-d160bcd3ef13731ac5d7aa43f0c1e76f5635c0a2284a2af2dd35c86a124aee5dR42-R52)

### DNS and Networking

* Updated DNS logic and resources to optionally create a secondary public DNS record and link it to the new public IP when enabled. Also clarified required firewall/NSG rules for the secondary endpoint. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R35) [[2]](diffhunk://#diff-d160bcd3ef13731ac5d7aa43f0c1e76f5635c0a2284a2af2dd35c86a124aee5dL8-R8) [[3]](diffhunk://#diff-d160bcd3ef13731ac5d7aa43f0c1e76f5635c0a2284a2af2dd35c86a124aee5dR26) [[4]](diffhunk://#diff-d160bcd3ef13731ac5d7aa43f0c1e76f5635c0a2284a2af2dd35c86a124aee5dR42-R52)

### Integration and Hostname Selection

* Added variables to control which hostname (primary or secondary) is used for OIDC, VCS, and run task integrations, giving users flexibility in integration routing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R341) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R350-R356) [[3]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR60-R61) [[4]](diffhunk://#diff-a7ea65a6f62fd2b56d51e12bb2790384233faad22d703ec078b31c24eb3d86eaR73-R74)

### Documentation and Outputs

* Updated documentation to describe the new secondary endpoint feature, required secrets, and integration options. Added outputs for the secondary URL and public IP address. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R372-R377)

These changes allow users to deploy TFE with an additional, dedicated public endpoint for integrations, improving separation of user and integration traffic and enhancing security and flexibility.## Summary
- port the upstream secondary hostname support from AWS PR #48 into the Azure VM module
- add runtime settings and secondary TLS material for OIDC, VCS, and run task hostname selection
- optionally manage a second public Azure load balancer frontend, public IP, DNS record, and spec/plan/tasks docs for the Azure implementation

## Upstream references
- hashicorp/terraform-aws-terraform-enterprise-hvd#48