### PR TITLE
feat(variables): add validation to tfe_image_tag variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,20 +177,20 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.67 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.60 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.67 |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.60 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_dns_a_record.tfe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_key_vault_access_policy.postgres_cmk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.storage_account_cmk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -244,7 +244,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_bootstrap_keyvault_name"></a> [bootstrap\_keyvault\_name](#input\_bootstrap\_keyvault\_name) | Name of the 'bootstrap' Key Vault to use for bootstrapping TFE deployment. | `string` | n/a | yes |
 | <a name="input_bootstrap_keyvault_rg_name"></a> [bootstrap\_keyvault\_rg\_name](#input\_bootstrap\_keyvault\_rg\_name) | Name of the Resource Group where the 'bootstrap' Key Vault resides. | `string` | n/a | yes |
 | <a name="input_container_runtime"></a> [container\_runtime](#input\_container\_runtime) | Value of container runtime to use for TFE deployment. For Redhat, the default is `podman`, but optionally `docker` can be used. For Ubuntu, the default is `docker`. | `string` | n/a | yes |
@@ -365,7 +365,7 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_tfe_admin_console_url_pattern"></a> [tfe\_admin\_console\_url\_pattern](#output\_tfe\_admin\_console\_url\_pattern) | URL pattern to access the TFE Admin Console when it is enabled. |
 | <a name="output_tfe_database_host"></a> [tfe\_database\_host](#output\_tfe\_database\_host) | FQDN and port of PostgreSQL Flexible Server. |
 | <a name="output_tfe_database_name"></a> [tfe\_database\_name](#output\_tfe\_database\_name) | Name of PostgreSQL Flexible Server database. |

--- a/examples/main/variables.tf
+++ b/examples/main/variables.tf
@@ -145,6 +145,15 @@ variable "tfe_image_tag" {
   type        = string
   description = "Tag for the TFE container image. This represents the version of TFE to deploy."
   default     = "v202502-1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
+    )
+    error_message = "tfe_image_tag must be a supported calver tag (for example v202409-3), semver tag (for example 1.2.1 or v1.2.1), or raw commit hash."
+  }
 }
 
 variable "tfe_image_repository_username" {

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,15 @@ variable "tfe_image_tag" {
   type        = string
   description = "Tag for the TFE container image. This represents the version of TFE to deploy."
   default     = "v202502-1"
+
+  validation {
+    condition = (
+      can(regex("^v[0-9]{6}-[0-9]+$", var.tfe_image_tag)) ||
+      can(regex("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$", var.tfe_image_tag)) ||
+      can(regex("^[0-9a-f]{7,}$", var.tfe_image_tag))
+    )
+    error_message = "tfe_image_tag must be a supported calver tag (for example v202409-3), semver tag (for example 1.2.1 or v1.2.1), or raw commit hash."
+  }
 }
 
 variable "tfe_image_repository_username" {


### PR DESCRIPTION
## Description
Add input validation to the `tfe_image_tag` variable to enforce accepted tag formats and surface a clear error message when an unsupported value is supplied.

## Related issue
Closes #26

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested
- Validation block accepts the current default (`v202502-1`) and representative calver, semver, and commit-hash values.
- `terraform validate` passes against the root module and `examples/main`.
- README.md regenerated with `terraform-docs`.

## Accepted formats
| Format | Example |
|---|---|
| CalVer | `v202409-3` |
| SemVer (with or without `v`) | `1.2.1` / `v1.2.1` |
| Commit hash (>=7 chars) | `abc1234` |

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] `terraform fmt` passes
- [x] `terraform validate` passes